### PR TITLE
Player villager bags

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Tue Apr 10 14:03:42 CAT 2018
-build.number=497
+#Sat Jun 02 16:08:02 MSK 2018
+build.number=498

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Tue Apr 10 14:03:42 CAT 2018
-build.number=497
+#Mon Jun 04 04:49:51 MSK 2018
+build.number=498

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Sat Jun 02 16:08:02 MSK 2018
-build.number=498
+#Tue Apr 10 14:03:42 CAT 2018
+build.number=497

--- a/src/main/java/com/minelittlepony/model/components/ModelWing.java
+++ b/src/main/java/com/minelittlepony/model/components/ModelWing.java
@@ -51,13 +51,11 @@ public class ModelWing {
     }
 
 
-    public void render(boolean hasBags, boolean extend, float scale) {
+    public void render(boolean extend, float scale) {
         extended.rotationPointX = (mirror ? -1 : 1) * LEFT_WING_EXT_RP_X;
-        extended.rotationPointY = LEFT_WING_EXT_RP_Y + (hasBags ? -1f : 0f);
-        extended.rotationPointZ = LEFT_WING_EXT_RP_Z + (hasBags ? 1f : 0f);
-        extended.rotateAngleY = 3;
+        extended.rotationPointY = LEFT_WING_EXT_RP_Y;
 
-        folded.offset((hasBags ? (mirror ? -0.5f : 0.5f) : 0f), (hasBags ? -0.5f : 0f), (hasBags ? -1.5f : 0f));
+        extended.rotateAngleY = 3;
         if (extend) {
             extended.render(scale);
         } else {

--- a/src/main/java/com/minelittlepony/model/components/ModelWing.java
+++ b/src/main/java/com/minelittlepony/model/components/ModelWing.java
@@ -51,11 +51,13 @@ public class ModelWing {
     }
 
 
-    public void render(boolean extend, float scale) {
+    public void render(boolean hasBags, boolean extend, float scale) {
         extended.rotationPointX = (mirror ? -1 : 1) * LEFT_WING_EXT_RP_X;
-        extended.rotationPointY = LEFT_WING_EXT_RP_Y;
-
+        extended.rotationPointY = LEFT_WING_EXT_RP_Y + (hasBags ? -1f : 0f);
+        extended.rotationPointZ = LEFT_WING_EXT_RP_Z + (hasBags ? 1f : 0f);
         extended.rotateAngleY = 3;
+
+        folded.offset((hasBags ? (mirror ? -0.5f : 0.5f) : 0f), (hasBags ? -0.5f : 0f), (hasBags ? -1.5f : 0f));
         if (extend) {
             extended.render(scale);
         } else {

--- a/src/main/java/com/minelittlepony/model/components/PegasusWings.java
+++ b/src/main/java/com/minelittlepony/model/components/PegasusWings.java
@@ -18,10 +18,8 @@ public class PegasusWings implements IModelPart {
     public <T extends AbstractPonyModel & IModelPegasus> PegasusWings(T model, float yOffset, float stretch) {
         pegasus = model;
 
-        boolean hasBags = ((AbstractPonyModel) pegasus).metadata.hasBags();
-        if (hasBags) yOffset -= 12f;
-        leftWing = new ModelWing(model, false, 4f - (hasBags ? -0.5f : 0f), yOffset, stretch, 32);
-        rightWing = new ModelWing(model, true, (hasBags ? -0.5f : 0f) - 6f, yOffset, stretch, hasBags ? 32 : 16);
+        leftWing = new ModelWing(model, false, 4f, yOffset, stretch, 32);
+        rightWing = new ModelWing(model, true, -6f, yOffset, stretch, 16);
     }
 
 
@@ -70,10 +68,11 @@ public class PegasusWings implements IModelPart {
     @Override
     public void render(float scale) {
         AbstractPonyModel model = ((AbstractPonyModel) pegasus);
-        if (!model.metadata.hasBags() || model.textureHeight == 64) {
+        boolean hasBags = model.metadata.hasBags();
+        if (!hasBags || model.textureHeight == 64) {
             boolean standing = pegasus.wingsAreOpen();
-            leftWing.render(standing, scale);
-            rightWing.render(standing, scale);
+            leftWing.render(hasBags, standing, scale);
+            rightWing.render(hasBags, standing, scale);
         }
     }
 }

--- a/src/main/java/com/minelittlepony/model/components/PegasusWings.java
+++ b/src/main/java/com/minelittlepony/model/components/PegasusWings.java
@@ -18,8 +18,10 @@ public class PegasusWings implements IModelPart {
     public <T extends AbstractPonyModel & IModelPegasus> PegasusWings(T model, float yOffset, float stretch) {
         pegasus = model;
 
-        leftWing = new ModelWing(model, false, 4f, yOffset, stretch, 32);
-        rightWing = new ModelWing(model, true, -6f, yOffset, stretch, 16);
+        boolean hasBags = ((AbstractPonyModel) pegasus).metadata.hasBags();
+        if (hasBags) yOffset -= 12f;
+        leftWing = new ModelWing(model, false, 4f - (hasBags ? -0.5f : 0f), yOffset, stretch, 32);
+        rightWing = new ModelWing(model, true, (hasBags ? -0.5f : 0f) - 6f, yOffset, stretch, hasBags ? 32 : 16);
     }
 
 
@@ -67,8 +69,11 @@ public class PegasusWings implements IModelPart {
 
     @Override
     public void render(float scale) {
-        boolean standing = pegasus.wingsAreOpen();
-        leftWing.render(standing, scale);
-        rightWing.render(standing, scale);
+        AbstractPonyModel model = ((AbstractPonyModel) pegasus);
+        if (!model.metadata.hasBags() || model.textureHeight == 64) {
+            boolean standing = pegasus.wingsAreOpen();
+            leftWing.render(standing, scale);
+            rightWing.render(standing, scale);
+        }
     }
 }

--- a/src/main/java/com/minelittlepony/model/components/PegasusWings.java
+++ b/src/main/java/com/minelittlepony/model/components/PegasusWings.java
@@ -68,11 +68,10 @@ public class PegasusWings implements IModelPart {
     @Override
     public void render(float scale) {
         AbstractPonyModel model = ((AbstractPonyModel) pegasus);
-        boolean hasBags = model.metadata.hasBags();
-        if (!hasBags || model.textureHeight == 64) {
+        if (!model.metadata.hasBags() || model.textureHeight == 64) {
             boolean standing = pegasus.wingsAreOpen();
-            leftWing.render(hasBags, standing, scale);
-            rightWing.render(hasBags, standing, scale);
+            leftWing.render(standing, scale);
+            rightWing.render(standing, scale);
         }
     }
 }

--- a/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
@@ -14,17 +14,11 @@ public class PonyAccessory implements IModelPart {
 
     public PlaneRenderer bag;
 
-    public <T extends AbstractPonyModel> PonyAccessory(T model) {
+    public <T extends AbstractPonyModel> PonyAccessory(T model, float yOffset, float stretch) {
         theModel = model;
 
         if (theModel.metadata.hasBags()) {
             bag = new PlaneRenderer(theModel, 56, 19);
-        }
-    }
-
-    @Override
-    public void init(float yOffset, float stretch) {
-        if (bag != null && theModel.metadata.hasBags()) {
             bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
                .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
                .tex(56, 25).addBackPlane(-7,     -5,    -4, 3, 6, stretch) //right bag front
@@ -47,7 +41,11 @@ public class PonyAccessory implements IModelPart {
         }
     }
 
-    @Override  // I really didn't know, what to do here, but since this has to be overridden...
+    @Override
+    public void init(float yOffset, float stretch) {
+    }
+
+    @Override
     public void setRotationAndAngles(boolean rainboom, float move, float swing, float bodySwing, float ticks) {
     }
 

--- a/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
@@ -3,8 +3,6 @@ package com.minelittlepony.model.components;
 import com.minelittlepony.model.AbstractPonyModel;
 import com.minelittlepony.model.capabilities.IModelPart;
 import com.minelittlepony.render.plane.PlaneRenderer;
-import net.minecraft.entity.Entity;
-import net.minecraft.util.math.MathHelper;
 
 import static com.minelittlepony.model.PonyModelConstants.*;
 

--- a/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
@@ -1,0 +1,62 @@
+package com.minelittlepony.model.components;
+
+import com.minelittlepony.model.AbstractPonyModel;
+import com.minelittlepony.render.plane.PlaneRenderer;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.MathHelper;
+
+import static com.minelittlepony.model.PonyModelConstants.*;
+
+public class PonyAccessory {
+
+    private final AbstractPonyModel theModel;
+
+    public PlaneRenderer bag;
+
+    public <T extends AbstractPonyModel> PonyAccessory(T model) {
+        theModel = model;
+
+        if (theModel.metadata.hasBags()) {
+            bag = new PlaneRenderer(theModel, 56, 19);
+        }
+    }
+
+    public void setRotationAndAngles(float move, float swing, float ticks, float headYaw, float headPitch, float scale, Entity entity) {
+        float angleY = 0;
+        if (theModel.swingProgress > -9990.0F && !theModel.metadata.hasMagic()) {
+            angleY = MathHelper.sin(MathHelper.sqrt(theModel.swingProgress) * PI * 2) * 0.02F;
+        }
+        bag.rotateAngleY = angleY;
+
+    }
+
+    public void render(float scale) {
+        if (bag != null && theModel.metadata.hasBags()) {
+            bag.render(scale);
+        }
+    }
+
+    public void initPositions(float yOffset, float stretch) {
+        if (bag != null && theModel.metadata.hasBags()) {
+            bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
+                    .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
+                    .tex(56, 25).addBackPlane(-7, -5, -4, 3, 6, stretch) //right bag front
+                    .addBackPlane(4, -5, -4, 3, 6, stretch) //left bag front
+                    .tex(59, 25).addBackPlane(-7, -5, 4, 3, 6, stretch) //right bag back
+                    .addBackPlane(4, -5, 4, 3, 6, stretch) //left bag back
+                    .tex(56, 19).addWestPlane(-7, -5, -4, 6, 8, stretch) //right bag outside
+                    .addWestPlane(7, -5, -4, 6, 8, stretch) //left bag outside
+                    .addWestPlane(-4.01f, -5, -4, 6, 8, stretch) //right bag inside
+                    .addWestPlane(4.01f, -5, -4, 6, 8, stretch) //left bag inside
+                    .tex(56, 31).addTopPlane(-4, -4.5F, -1, 8, 1, stretch) //strap front
+                    .addTopPlane(-4, -4.5F, 0, 8, 1, stretch) //strap back
+                    .addBackPlane(-4, -4.5F, 0, 8, 1, stretch)
+                    .addFrontPlane(-4, -4.5F, 0, 8, 1, stretch)
+                    .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
+                    .addTopPlane(2, -5, -2, 8, 3, stretch) //right bag top
+                    .tex(56, 22).flipZ().addBottomPlane(2, 1, -13, 8, 3, stretch) //left bag bottom
+                    .flipZ().addBottomPlane(2, 1, -2, 8, 3, stretch) //right bag bottom
+                    .rotateAngleY = 4.712389F;
+        }
+    }
+}

--- a/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
@@ -1,13 +1,14 @@
 package com.minelittlepony.model.components;
 
 import com.minelittlepony.model.AbstractPonyModel;
+import com.minelittlepony.model.capabilities.IModelPart;
 import com.minelittlepony.render.plane.PlaneRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.MathHelper;
 
 import static com.minelittlepony.model.PonyModelConstants.*;
 
-public class PonyAccessory {
+public class PonyAccessory implements IModelPart {
 
     private final AbstractPonyModel theModel;
 
@@ -21,42 +22,44 @@ public class PonyAccessory {
         }
     }
 
-    public void setRotationAndAngles(float move, float swing, float ticks, float headYaw, float headPitch, float scale, Entity entity) {
-        float angleY = 0;
-        if (theModel.swingProgress > -9990.0F && !theModel.metadata.hasMagic()) {
-            angleY = MathHelper.sin(MathHelper.sqrt(theModel.swingProgress) * PI * 2) * 0.02F;
+    @Override
+    public void init(float yOffset, float stretch) {
+        if (bag != null && theModel.metadata.hasBags()) {
+            bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
+               .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
+               .tex(56, 25).addBackPlane(-7,     -5,    -4, 3, 6, stretch) //right bag front
+                           .addBackPlane( 4,     -5,    -4, 3, 6, stretch) //left bag front
+               .tex(59, 25).addBackPlane(-7,     -5,     4, 3, 6, stretch) //right bag back
+                           .addBackPlane( 4,     -5,     4, 3, 6, stretch) //left bag back
+               .tex(56, 19).addWestPlane(-7,     -5,    -4, 6, 8, stretch) //right bag outside
+                           .addWestPlane( 7,     -5,    -4, 6, 8, stretch) //left bag outside
+                           .addWestPlane(-4.01f, -5,    -4, 6, 8, stretch) //right bag inside
+                           .addWestPlane( 4.01f, -5,    -4, 6, 8, stretch) //left bag inside
+               .tex(56, 31) .addTopPlane(-4,     -4.5F, -1, 8, 1, stretch) //strap front
+                            .addTopPlane(-4,     -4.5F,  0, 8, 1, stretch) //strap back
+                           .addBackPlane(-4,     -4.5F,  0, 8, 1, stretch)
+                          .addFrontPlane(-4,     -4.5F,  0, 8, 1, stretch)
+               .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
+                            .flipZ().addTopPlane(2, -5,  -2, 8, 3, stretch) //right bag top
+                     .tex(56, 22).addBottomPlane(2,  1, -13, 8, 3, stretch) //left bag bottom
+                         .flipZ().addBottomPlane(2,  1,  -2, 8, 3, stretch) //right bag bottom
+                        .rotateAngleY = 4.712389F;
         }
-        bag.rotateAngleY = angleY;
+    }
 
+    @Override  // I really didn't know, what to do here, but since this has to be overridden...
+    public void setRotationAndAngles(boolean rainboom, float move, float swing, float bodySwing, float ticks) {
+    }
+
+    public void shakeBody(float bodySwing) {
+        if (bag != null && theModel.metadata.hasBags()) {
+            bag.rotateAngleY = bodySwing;
+        }
     }
 
     public void render(float scale) {
         if (bag != null && theModel.metadata.hasBags()) {
             bag.render(scale);
-        }
-    }
-
-    public void initPositions(float yOffset, float stretch) {
-        if (bag != null && theModel.metadata.hasBags()) {
-            bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
-                    .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
-                    .tex(56, 25).addBackPlane(-7, -5, -4, 3, 6, stretch) //right bag front
-                    .addBackPlane(4, -5, -4, 3, 6, stretch) //left bag front
-                    .tex(59, 25).addBackPlane(-7, -5, 4, 3, 6, stretch) //right bag back
-                    .addBackPlane(4, -5, 4, 3, 6, stretch) //left bag back
-                    .tex(56, 19).addWestPlane(-7, -5, -4, 6, 8, stretch) //right bag outside
-                    .addWestPlane(7, -5, -4, 6, 8, stretch) //left bag outside
-                    .addWestPlane(-4.01f, -5, -4, 6, 8, stretch) //right bag inside
-                    .addWestPlane(4.01f, -5, -4, 6, 8, stretch) //left bag inside
-                    .tex(56, 31).addTopPlane(-4, -4.5F, -1, 8, 1, stretch) //strap front
-                    .addTopPlane(-4, -4.5F, 0, 8, 1, stretch) //strap back
-                    .addBackPlane(-4, -4.5F, 0, 8, 1, stretch)
-                    .addFrontPlane(-4, -4.5F, 0, 8, 1, stretch)
-                    .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
-                    .addTopPlane(2, -5, -2, 8, 3, stretch) //right bag top
-                    .tex(56, 22).flipZ().addBottomPlane(2, 1, -13, 8, 3, stretch) //left bag bottom
-                    .flipZ().addBottomPlane(2, 1, -2, 8, 3, stretch) //right bag bottom
-                    .rotateAngleY = 4.712389F;
         }
     }
 }

--- a/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/model/components/PonyAccessory.java
@@ -17,28 +17,26 @@ public class PonyAccessory implements IModelPart {
     public <T extends AbstractPonyModel> PonyAccessory(T model, float yOffset, float stretch) {
         theModel = model;
 
-        if (theModel.metadata.hasBags()) {
-            bag = new PlaneRenderer(theModel, 56, 19);
-            bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
-               .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
-               .tex(56, 25).addBackPlane(-7,     -5,    -4, 3, 6, stretch) //right bag front
-                           .addBackPlane( 4,     -5,    -4, 3, 6, stretch) //left bag front
-               .tex(59, 25).addBackPlane(-7,     -5,     4, 3, 6, stretch) //right bag back
-                           .addBackPlane( 4,     -5,     4, 3, 6, stretch) //left bag back
-               .tex(56, 19).addWestPlane(-7,     -5,    -4, 6, 8, stretch) //right bag outside
-                           .addWestPlane( 7,     -5,    -4, 6, 8, stretch) //left bag outside
-                           .addWestPlane(-4.01f, -5,    -4, 6, 8, stretch) //right bag inside
-                           .addWestPlane( 4.01f, -5,    -4, 6, 8, stretch) //left bag inside
-               .tex(56, 31) .addTopPlane(-4,     -4.5F, -1, 8, 1, stretch) //strap front
-                            .addTopPlane(-4,     -4.5F,  0, 8, 1, stretch) //strap back
-                           .addBackPlane(-4,     -4.5F,  0, 8, 1, stretch)
-                          .addFrontPlane(-4,     -4.5F,  0, 8, 1, stretch)
-               .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
-                            .flipZ().addTopPlane(2, -5,  -2, 8, 3, stretch) //right bag top
-                     .tex(56, 22).addBottomPlane(2,  1, -13, 8, 3, stretch) //left bag bottom
-                         .flipZ().addBottomPlane(2,  1,  -2, 8, 3, stretch) //right bag bottom
-                        .rotateAngleY = 4.712389F;
-        }
+        bag = new PlaneRenderer(theModel, 56, 19);
+        bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
+           .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
+           .tex(56, 25).addBackPlane(-7,     -5,    -4, 3, 6, stretch) //right bag front
+                       .addBackPlane( 4,     -5,    -4, 3, 6, stretch) //left bag front
+           .tex(59, 25).addBackPlane(-7,     -5,     4, 3, 6, stretch) //right bag back
+                       .addBackPlane( 4,     -5,     4, 3, 6, stretch) //left bag back
+           .tex(56, 19).addWestPlane(-7,     -5,    -4, 6, 8, stretch) //right bag outside
+                       .addWestPlane( 7,     -5,    -4, 6, 8, stretch) //left bag outside
+                       .addWestPlane(-4.01f, -5,    -4, 6, 8, stretch) //right bag inside
+                       .addWestPlane( 4.01f, -5,    -4, 6, 8, stretch) //left bag inside
+           .tex(56, 31) .addTopPlane(-4,     -4.5F, -1, 8, 1, stretch) //strap front
+                        .addTopPlane(-4,     -4.5F,  0, 8, 1, stretch) //strap back
+                       .addBackPlane(-4,     -4.5F,  0, 8, 1, stretch)
+                      .addFrontPlane(-4,     -4.5F,  0, 8, 1, stretch)
+           .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
+                        .flipZ().addTopPlane(2, -5,  -2, 8, 3, stretch) //right bag top
+                 .tex(56, 22).addBottomPlane(2,  1, -13, 8, 3, stretch) //left bag bottom
+                     .flipZ().addBottomPlane(2,  1,  -2, 8, 3, stretch) //right bag bottom
+                    .rotateAngleY = 4.712389F;
     }
 
     @Override

--- a/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
+++ b/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
@@ -21,9 +21,8 @@ public class ModelEarthPony extends AbstractPonyModel {
     @Override
     public void init(float yOffset, float stretch) {
         super.init(yOffset, stretch);
-
-        if (accessory != null && metadata.hasAccessory()) {
-            accessory.init(yOffset, stretch);
+        if (metadata.hasAccessory()) {
+            accessory = new PonyAccessory(this, yOffset, stretch);
         }
     }
 
@@ -40,14 +39,6 @@ public class ModelEarthPony extends AbstractPonyModel {
         super.renderBody(entity, move, swing, ticks, headYaw, headPitch, scale);
         if (accessory != null && metadata.hasAccessory()) {
             accessory.render(scale);
-        }
-    }
-
-    @Override
-    protected void initTextures() {
-        super.initTextures();
-        if (metadata.hasAccessory()) {
-            accessory = new PonyAccessory(this);
         }
     }
 

--- a/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
+++ b/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
@@ -21,9 +21,7 @@ public class ModelEarthPony extends AbstractPonyModel {
     @Override
     public void init(float yOffset, float stretch) {
         super.init(yOffset, stretch);
-        if (metadata.hasAccessory()) {
-            accessory = new PonyAccessory(this, yOffset, stretch);
-        }
+        accessory = new PonyAccessory(this, yOffset, stretch);
     }
 
     @Override

--- a/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
+++ b/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
@@ -3,13 +3,18 @@ package com.minelittlepony.model.player;
 import com.minelittlepony.model.AbstractPonyModel;
 import com.minelittlepony.render.PonyRenderer;
 
+import com.minelittlepony.render.plane.PlaneRenderer;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.math.MathHelper;
+
+import static com.minelittlepony.model.PonyModelConstants.*;
 
 public class ModelEarthPony extends AbstractPonyModel {
 
     private final boolean smallArms;
 
     public PonyRenderer bipedCape;
+    public PlaneRenderer bag;
 
     public ModelEarthPony(boolean smallArms) {
         super(smallArms);
@@ -23,6 +28,59 @@ public class ModelEarthPony extends AbstractPonyModel {
         if (bipedCape != null) {
             bipedCape.rotationPointY = isSneak ? 2 : isRiding ? -4 : 0;
         }
+        if (bag != null && metadata.hasBags()) {
+            float angleY = 0;
+            if (swingProgress > -9990.0F && !metadata.hasMagic()) {
+                angleY = MathHelper.sin(MathHelper.sqrt(swingProgress) * PI * 2) * 0.02F;
+            }
+            bag.rotateAngleY = angleY;
+        }
+    }
+
+    @Override
+    protected void renderBody(Entity entity, float move, float swing, float ticks, float headYaw, float headPitch, float scale) {
+        super.renderBody(entity, move, swing, ticks, headYaw, headPitch, scale);
+
+        bipedBody.postRender(this.scale);
+        if (bag != null && metadata.hasBags()) {
+            bag.render(scale);
+        }
+    }
+
+    @Override
+    protected void initTextures() {
+        super.initTextures();
+        if (metadata.hasBags()) {
+            bag = new PlaneRenderer(this, 56, 19);
+        }
+    }
+
+    @Override
+    protected void initPositions(float yOffset, float stretch) {
+        super.initPositions(yOffset, stretch);
+
+        if (bag == null || !metadata.hasBags()) {
+            return;
+        }
+        bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
+                .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
+                .tex(56, 25).addBackPlane(-7, -5, -4, 3, 6, stretch) //right bag front
+                .addBackPlane(4, -5, -4, 3, 6, stretch) //left bag front
+                .tex(59, 25).addBackPlane(-7, -5, 4, 3, 6, stretch) //right bag back
+                .addBackPlane(4, -5, 4, 3, 6, stretch) //left bag back
+                .tex(56, 19).addWestPlane(-7, -5, -4, 6, 8, stretch) //right bag outside
+                .addWestPlane(7, -5, -4, 6, 8, stretch) //left bag outside
+                .addWestPlane(-4.01f, -5, -4, 6, 8, stretch) //right bag inside
+                .addWestPlane(4.01f, -5, -4, 6, 8, stretch) //left bag inside
+                .tex(56, 31).addTopPlane(-4, -4.5F, -1, 8, 1, stretch) //strap front
+                .addTopPlane(-4, -4.5F, 0, 8, 1, stretch) //strap back
+                .addBackPlane(-4, -4.5F, 0, 8, 1, stretch)
+                .addFrontPlane(-4, -4.5F, 0, 8, 1, stretch)
+                .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
+                .addTopPlane(2, -5, -2, 8, 3, stretch) //right bag top
+                .tex(56, 22).flipZ().addBottomPlane(2, 1, -13, 8, 3, stretch) //left bag bottom
+                .flipZ().addBottomPlane(2, 1, -2, 8, 3, stretch) //right bag bottom
+                .rotateAngleY = 4.712389F;
     }
 
     protected float getLegOutset() {

--- a/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
+++ b/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
@@ -1,20 +1,17 @@
 package com.minelittlepony.model.player;
 
 import com.minelittlepony.model.AbstractPonyModel;
+import com.minelittlepony.model.components.PonyAccessory;
 import com.minelittlepony.render.PonyRenderer;
 
-import com.minelittlepony.render.plane.PlaneRenderer;
 import net.minecraft.entity.Entity;
-import net.minecraft.util.math.MathHelper;
-
-import static com.minelittlepony.model.PonyModelConstants.*;
 
 public class ModelEarthPony extends AbstractPonyModel {
 
     private final boolean smallArms;
 
     public PonyRenderer bipedCape;
-    public PlaneRenderer bag;
+    public PonyAccessory accessory;
 
     public ModelEarthPony(boolean smallArms) {
         super(smallArms);
@@ -28,12 +25,8 @@ public class ModelEarthPony extends AbstractPonyModel {
         if (bipedCape != null) {
             bipedCape.rotationPointY = isSneak ? 2 : isRiding ? -4 : 0;
         }
-        if (bag != null && metadata.hasBags()) {
-            float angleY = 0;
-            if (swingProgress > -9990.0F && !metadata.hasMagic()) {
-                angleY = MathHelper.sin(MathHelper.sqrt(swingProgress) * PI * 2) * 0.02F;
-            }
-            bag.rotateAngleY = angleY;
+        if (accessory != null && metadata.hasAccessory()) {
+            accessory.setRotationAndAngles(move, swing, ticks, headYaw, headPitch, scale, entity);
         }
     }
 
@@ -42,16 +35,16 @@ public class ModelEarthPony extends AbstractPonyModel {
         super.renderBody(entity, move, swing, ticks, headYaw, headPitch, scale);
 
         bipedBody.postRender(this.scale);
-        if (bag != null && metadata.hasBags()) {
-            bag.render(scale);
+        if (accessory != null && metadata.hasAccessory()) {
+            accessory.render(scale);
         }
     }
 
     @Override
     protected void initTextures() {
         super.initTextures();
-        if (metadata.hasBags()) {
-            bag = new PlaneRenderer(this, 56, 19);
+        if (metadata.hasAccessory()) {
+            accessory = new PonyAccessory(this);
         }
     }
 
@@ -59,28 +52,9 @@ public class ModelEarthPony extends AbstractPonyModel {
     protected void initPositions(float yOffset, float stretch) {
         super.initPositions(yOffset, stretch);
 
-        if (bag == null || !metadata.hasBags()) {
-            return;
+        if (accessory != null && metadata.hasAccessory()) {
+            accessory.initPositions(yOffset, stretch);
         }
-        bag.offset(BODY_CENTRE_X, BODY_CENTRE_Y, BODY_CENTRE_Z)
-                .around(HEAD_RP_X, HEAD_RP_Y + yOffset, HEAD_RP_Z)
-                .tex(56, 25).addBackPlane(-7, -5, -4, 3, 6, stretch) //right bag front
-                .addBackPlane(4, -5, -4, 3, 6, stretch) //left bag front
-                .tex(59, 25).addBackPlane(-7, -5, 4, 3, 6, stretch) //right bag back
-                .addBackPlane(4, -5, 4, 3, 6, stretch) //left bag back
-                .tex(56, 19).addWestPlane(-7, -5, -4, 6, 8, stretch) //right bag outside
-                .addWestPlane(7, -5, -4, 6, 8, stretch) //left bag outside
-                .addWestPlane(-4.01f, -5, -4, 6, 8, stretch) //right bag inside
-                .addWestPlane(4.01f, -5, -4, 6, 8, stretch) //left bag inside
-                .tex(56, 31).addTopPlane(-4, -4.5F, -1, 8, 1, stretch) //strap front
-                .addTopPlane(-4, -4.5F, 0, 8, 1, stretch) //strap back
-                .addBackPlane(-4, -4.5F, 0, 8, 1, stretch)
-                .addFrontPlane(-4, -4.5F, 0, 8, 1, stretch)
-                .child(0).tex(56, 16).addTopPlane(2, -5, -13, 8, 3, stretch) //left bag top
-                .addTopPlane(2, -5, -2, 8, 3, stretch) //right bag top
-                .tex(56, 22).flipZ().addBottomPlane(2, 1, -13, 8, 3, stretch) //left bag bottom
-                .flipZ().addBottomPlane(2, 1, -2, 8, 3, stretch) //right bag bottom
-                .rotateAngleY = 4.712389F;
     }
 
     protected float getLegOutset() {

--- a/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
+++ b/src/main/java/com/minelittlepony/model/player/ModelEarthPony.java
@@ -19,22 +19,25 @@ public class ModelEarthPony extends AbstractPonyModel {
     }
 
     @Override
-    public void setRotationAngles(float move, float swing, float ticks, float headYaw, float headPitch, float scale, Entity entity) {
-        super.setRotationAngles(move, swing, ticks, headYaw, headPitch, scale, entity);
+    public void init(float yOffset, float stretch) {
+        super.init(yOffset, stretch);
 
-        if (bipedCape != null) {
-            bipedCape.rotationPointY = isSneak ? 2 : isRiding ? -4 : 0;
-        }
         if (accessory != null && metadata.hasAccessory()) {
-            accessory.setRotationAndAngles(move, swing, ticks, headYaw, headPitch, scale, entity);
+            accessory.init(yOffset, stretch);
+        }
+    }
+
+    @Override
+    protected void shakeBody(float move, float swing, float bodySwing, float ticks) {
+        super.shakeBody(move, swing, bodySwing, ticks);
+        if (accessory != null && metadata.hasAccessory()) {
+            accessory.shakeBody(bodySwing);
         }
     }
 
     @Override
     protected void renderBody(Entity entity, float move, float swing, float ticks, float headYaw, float headPitch, float scale) {
         super.renderBody(entity, move, swing, ticks, headYaw, headPitch, scale);
-
-        bipedBody.postRender(this.scale);
         if (accessory != null && metadata.hasAccessory()) {
             accessory.render(scale);
         }
@@ -49,11 +52,11 @@ public class ModelEarthPony extends AbstractPonyModel {
     }
 
     @Override
-    protected void initPositions(float yOffset, float stretch) {
-        super.initPositions(yOffset, stretch);
+    public void setRotationAngles(float move, float swing, float ticks, float headYaw, float headPitch, float scale, Entity entity) {
+        super.setRotationAngles(move, swing, ticks, headYaw, headPitch, scale, entity);
 
-        if (accessory != null && metadata.hasAccessory()) {
-            accessory.initPositions(yOffset, stretch);
+        if (bipedCape != null) {
+            bipedCape.rotationPointY = isSneak ? 2 : isRiding ? -4 : 0;
         }
     }
 

--- a/src/main/java/com/minelittlepony/pony/data/IPonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/IPonyData.java
@@ -35,4 +35,9 @@ public interface IPonyData extends IMetadataSection {
      * Returns true if and only if this metadata represents a pony that can cast magic.
      */
     boolean hasMagic();
+
+    /**
+     * Returns true if and only if this metadata represents a pony that has bags.
+     */
+    boolean hasBags();
 }

--- a/src/main/java/com/minelittlepony/pony/data/IPonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/IPonyData.java
@@ -37,7 +37,7 @@ public interface IPonyData extends IMetadataSection {
     boolean hasMagic();
 
     /**
-     * Returns true if and only if this metadata represents a pony that has bags.
+     * Returns true if and only if this metadata represents a pony that has accessories.
      */
     boolean hasAccessory();
 

--- a/src/main/java/com/minelittlepony/pony/data/IPonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/IPonyData.java
@@ -39,5 +39,10 @@ public interface IPonyData extends IMetadataSection {
     /**
      * Returns true if and only if this metadata represents a pony that has bags.
      */
+    boolean hasAccessory();
+
+    /**
+     * Returns true if and only if this metadata represents a pony that has bags.
+     */
     boolean hasBags();
 }

--- a/src/main/java/com/minelittlepony/pony/data/PonyAccessory.java
+++ b/src/main/java/com/minelittlepony/pony/data/PonyAccessory.java
@@ -1,0 +1,18 @@
+package com.minelittlepony.pony.data;
+
+public enum PonyAccessory implements ITriggerPixelMapped<PonyAccessory> {
+
+    SADDLEBAGS(0x442300),
+    NONE(0);
+
+    private int triggerValue;
+
+    PonyAccessory(int pixel) {
+        triggerValue = pixel;
+    }
+
+    @Override
+    public int getTriggerPixel() {
+        return triggerValue;
+    }
+}

--- a/src/main/java/com/minelittlepony/pony/data/PonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/PonyData.java
@@ -84,6 +84,7 @@ public class PonyData implements IPonyData {
                 .add("gender", gender)
                 .add("size", size)
                 .add("glowColor", "#" + Integer.toHexString(glowColor))
+                .add("accessory", accessory)
                 .toString();
     }
 

--- a/src/main/java/com/minelittlepony/pony/data/PonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/PonyData.java
@@ -18,6 +18,7 @@ public class PonyData implements IPonyData {
     private final PonyGender gender;
     private final PonySize size;
     private final int glowColor;
+    private final PonyAccessory accessory;
 
     public PonyData() {
         race = PonyRace.HUMAN;
@@ -25,6 +26,7 @@ public class PonyData implements IPonyData {
         gender = PonyGender.MARE;
         size = PonySize.NORMAL;
         glowColor = 0x4444aa;
+        accessory = PonyAccessory.NONE;
     }
 
     private PonyData(BufferedImage image) {
@@ -33,6 +35,7 @@ public class PonyData implements IPonyData {
         size = TriggerPixels.SIZE.readValue(image);
         gender = TriggerPixels.GENDER.readValue(image);
         glowColor = TriggerPixels.GLOW.readColor(image, -1);
+        accessory = TriggerPixels.ACCESSORY.readValue(image);
     }
 
     @Override
@@ -58,6 +61,10 @@ public class PonyData implements IPonyData {
     @Override
     public int getGlowColor() {
         return glowColor;
+    }
+
+    public boolean hasBags() {
+        return accessory == PonyAccessory.SADDLEBAGS;
     }
 
     @Override

--- a/src/main/java/com/minelittlepony/pony/data/PonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/PonyData.java
@@ -63,6 +63,10 @@ public class PonyData implements IPonyData {
         return glowColor;
     }
 
+    public boolean hasAccessory() {
+        return accessory != PonyAccessory.NONE;
+    }
+
     public boolean hasBags() {
         return accessory == PonyAccessory.SADDLEBAGS;
     }

--- a/src/main/java/com/minelittlepony/pony/data/TriggerPixels.java
+++ b/src/main/java/com/minelittlepony/pony/data/TriggerPixels.java
@@ -13,7 +13,7 @@ public enum TriggerPixels {
     GENDER(PonyGender.MARE, 2, 0),
     SIZE(PonySize.LARGE, 3, 0),
     GLOW(null, 0, 1),
-    ACCESSORY(PonyAccessory.NONE, 0, 2);
+    ACCESSORY(PonyAccessory.NONE, 1, 1);
 
     private int x;
     private int y;

--- a/src/main/java/com/minelittlepony/pony/data/TriggerPixels.java
+++ b/src/main/java/com/minelittlepony/pony/data/TriggerPixels.java
@@ -12,7 +12,8 @@ public enum TriggerPixels {
     TAIL(TailLengths.FULL, 1, 0),
     GENDER(PonyGender.MARE, 2, 0),
     SIZE(PonySize.LARGE, 3, 0),
-    GLOW(null, 0, 1);
+    GLOW(null, 0, 1),
+    ACCESSORY(PonyAccessory.NONE, 0, 2);
 
     private int x;
     private int y;


### PR DESCRIPTION
This is just a foundation of implementing #54 . A bunch of copied code from ModelVillagerPony, most certainly incorrectly converted to implement IModelPart, and with a separate trigger pixel.
Current problems: can't adjust texture offset for right wing and positions for both wings at runtime, as it all gets finalised upon model's init, where metadata is non-representative, and I'm too afraid to mess things up badly while rewriting ModelWing to make this possible.
Idea is like this: if a model tries to have both bags and wings (`metadata.getRace().hasWings()` and `metadata.hasBags()`) - wings are only rendered if texture is 64 high (new skin layout), otherwise only bags are shown - we assume that if bag trigger pixel is set, then skin author wants them more; and wings should be moved a little bit to the inside, upwards and backwards to look more show-accurately. First part is implemented already through editing PegasusWings, but movement and texture shifting are beyond my humble abilities.