### PR TITLE
Friendlier Access Modifiers

### DIFF
--- a/src/main/java/com/minelittlepony/model/AbstractPonyModel.java
+++ b/src/main/java/com/minelittlepony/model/AbstractPonyModel.java
@@ -33,11 +33,11 @@ import static com.minelittlepony.model.PonyModelConstants.*;
  */
 public abstract class AbstractPonyModel extends ModelPlayer implements IModel {
 
-    private boolean isSleeping;
-    private boolean isFlying;
-    private boolean isElytraFlying;
-    private boolean isSwimming;
-    private boolean headGear;
+    public boolean isSleeping;
+    public boolean isFlying;
+    public boolean isElytraFlying;
+    public boolean isSwimming;
+    public boolean headGear;
 
     /**
      * Associcated pony data.

--- a/src/main/java/com/minelittlepony/pony/data/PonyData.java
+++ b/src/main/java/com/minelittlepony/pony/data/PonyData.java
@@ -100,7 +100,7 @@ public class PonyData implements IPonyData {
     /**
      * Parses an image buffer into a new IPonyData representing the values stored in it's individual trigger pixels.
      */
-    static IPonyData parse(BufferedImage image) {
+    public static IPonyData parse(BufferedImage image) {
         return new PonyData(image);
     }
 }

--- a/src/main/java/com/minelittlepony/render/RenderPony.java
+++ b/src/main/java/com/minelittlepony/render/RenderPony.java
@@ -13,7 +13,7 @@ public class RenderPony<T extends EntityLivingBase> {
 
     public ModelWrapper playerModel;
 
-    private AbstractPonyModel ponyModel;
+    protected AbstractPonyModel ponyModel;
 
     private Pony pony;
 

--- a/src/main/java/com/minelittlepony/render/RenderPonyMob.java
+++ b/src/main/java/com/minelittlepony/render/RenderPonyMob.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 //       and is the whole reason we had this scaling bug in the first place.
 public abstract class RenderPonyMob<T extends EntityLiving> extends RenderLiving<T> implements IRenderPony<T> {
 
-    protected final RenderPony<T> renderPony = new RenderPony<T>(this);
+    protected RenderPony<T> renderPony = new RenderPony<T>(this);
 
     public RenderPonyMob(RenderManager manager, ModelWrapper model) {
         super(manager, model.getBody(), 0.5F);


### PR DESCRIPTION
Added support for potential external usage without going through Pony.class and potential swapping of models without swapping renders. Usages/Implementations not included.

The first part allows for mods to have a code dependency on this mod without having it as a mod dependency -- Mine Little Pony wouldn't need to be installed, simply required to be present and loaded for select sections to be utilized.