### PR TITLE
Repurposed ThreadDownloadImageEtag to be able to add client cache encryption

### DIFF
--- a/src/hdskins/java/com/voxelmodpack/hdskins/HDSkinManager.java
+++ b/src/hdskins/java/com/voxelmodpack/hdskins/HDSkinManager.java
@@ -23,6 +23,7 @@ import com.voxelmodpack.hdskins.gui.GuiSkins;
 import com.voxelmodpack.hdskins.resources.SkinResourceManager;
 import com.voxelmodpack.hdskins.resources.TextureLoader;
 import com.voxelmodpack.hdskins.resources.texture.ImageBufferDownloadHD;
+import com.voxelmodpack.hdskins.resources.texture.ThreadDownloadImageEncrypt;
 import com.voxelmodpack.hdskins.server.BethlehemSkinServer;
 import com.voxelmodpack.hdskins.server.LegacySkinServer;
 import com.voxelmodpack.hdskins.server.ServerType;
@@ -35,7 +36,6 @@ import com.voxelmodpack.hdskins.util.ProfileTextureUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.network.NetworkPlayerInfo;
-import net.minecraft.client.renderer.ThreadDownloadImageData;
 import net.minecraft.client.renderer.texture.ITextureObject;
 import net.minecraft.client.resources.DefaultPlayerSkin;
 import net.minecraft.client.resources.IResourceManager;
@@ -188,7 +188,7 @@ public final class HDSkinManager implements IResourceManagerReloadListener {
         } else {
 
             // schedule texture loading on the main thread.
-            TextureLoader.loadTexture(resource, new ThreadDownloadImageData(
+            TextureLoader.loadTexture(resource, new ThreadDownloadImageEncrypt(
                     new File(LiteLoader.getAssetsDirectory(), "hd/" + skinDir + texture.getHash().substring(0, 2) + "/" + texture.getHash()),
                     texture.getUrl(),
                     DefaultPlayerSkin.getDefaultSkinLegacy(),


### PR DESCRIPTION
Asked for a code review - was permitted to do a full PR. Well, there you have it :)

Stripped off the etag stuff, because it isn't needed anymore, and changed the method of file read/write operations since I need the raw bytes.