### PR TITLE
This should allow for unemployed villagers to use biome specific skins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/
 *.iml
 classes/
 out/
+.vscode/launch.json

--- a/src/main/java/com/minelittlepony/client/render/entity/npc/PonyTextures.java
+++ b/src/main/java/com/minelittlepony/client/render/entity/npc/PonyTextures.java
@@ -59,9 +59,6 @@ public class PonyTextures<T extends LivingEntity & VillagerDataContainer> implem
 
     private Identifier getTexture(final VillagerType type, final VillagerProfession profession) {
 
-        if (profession == VillagerProfession.NONE) {
-            return fallback;
-        }
 
         String key = ResourceUtil.format("pony/%s/%s", type, profession);
 


### PR DESCRIPTION
Allows biome specific skins for unemployed villagers by placing none.png in the related biome folder.