### PR TITLE
Updated dependency maven path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Stable Releases Channel: `https://repo.minelittlepony-mod.com/maven/release`
 
 Unstable Snapshot Channel: `https://repo.minelittlepony-mod.com/maven/snapshot`
 
-Dependency: `com.minelittlepony:MineLittlePony:<version>-1.15.2`
+Dependency: `com.minelittlepony:minelittlepony:<version>`
 
 Check [releases](https://github.com/MineLittlePony/MineLittlePony/releases) for the most recent release version or the `gradle.properties` for most recent snapshot version.


### PR DESCRIPTION
Dependency maven path was `com.minelittlepony:MineLittlePony`, even though starting with version 4.3.4 it changed to `com.minelittlepony:minelittlepony`